### PR TITLE
add fingerprint for HOBEIAN/ZG-101ZL 1-button smart scene switch

### DIFF
--- a/zigbee/button-battery/fingerprints.yaml
+++ b/zigbee/button-battery/fingerprints.yaml
@@ -379,6 +379,12 @@ zigbeeManufacturer:
     model: "TS004F"
     deviceProfileName: 4-button-battery
 
+  - id: "HOBEIAN/ZG-101ZL"
+    deviceLabel: "Scene Switch"
+    manufacturer: "HOBEIAN"
+    model: "ZG-101ZL"
+    deviceProfileName: 1-button-battery
+
   - id: "HOBEIAN/TS0044"
     deviceLabel: "Scene Switch"
     manufacturer: "HOBEIAN"
@@ -433,3 +439,4 @@ zigbeeManufacturer:
     manufacturer: "_TZ3000_itb0omhv"
     model: "TS0041"
     deviceProfileName: button-battery
+

--- a/zigbee/button-battery/fingerprints.yaml
+++ b/zigbee/button-battery/fingerprints.yaml
@@ -383,7 +383,7 @@ zigbeeManufacturer:
     deviceLabel: "Scene Switch"
     manufacturer: "HOBEIAN"
     model: "ZG-101ZL"
-    deviceProfileName: 1-button-battery
+    deviceProfileName: button-battery
 
   - id: "HOBEIAN/TS0044"
     deviceLabel: "Scene Switch"


### PR DESCRIPTION
Adds fingerprint for smart 1-button scene switch.

<img width="14445" height="7226" alt="HOBEIAN_ZG-101ZL_picB" src="https://github.com/user-attachments/assets/67213af4-fb5c-445e-9643-aed27ca7c4ea" />
<img width="13939" height="7412" alt="HOBEIAN_ZG-101ZL_picA" src="https://github.com/user-attachments/assets/e1999c87-7f84-47a7-bb90-3aab1db3c6e4" />
